### PR TITLE
Fix wrong filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can install the extension from source:
 
 Configure the extension to load with this PHP INI directive:
 
-    extension=tideways_xhprof.so
+    extension=tideways.so
 
 Restart Apache or PHP-FPM.
 


### PR DESCRIPTION
During the installation I recognized that the final shared object file has the wrong name.
(with v4.1.6)