### PR TITLE
More convenient usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ tideways_xhprof_enable();
 
 my_application();
 
-$data = tideways_xhprof_disable();
+file_put_contents(
+    sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid() . '.myapplication.xhprof',
+    serialize(tideways_xhprof_disable())
+);
 
-file_put_contents("/tmp/profile.xhprof", serialize($data));
 ```
 
 By default only wall clock time is measured, you can enable
@@ -79,7 +81,10 @@ tideways_xhprof_enable(TIDEWAYS_XHPROF_FLAGS_MEMORY | TIDEWAYS_XHPROF_FLAGS_CPU)
 
 my_application();
 
-$data = tideways_xhprof_disable();
+file_put_contents(
+    sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid() . '.myapplication.xhprof',
+    serialize(tideways_xhprof_disable())
+);
 ```
 
 ## Data-Format


### PR DESCRIPTION
More robust usage example;
Dump file name meets old xhprof_html viewer issue: it won't open if file
has another name format;

Matches with example at https://tideways.com/profiler/xhprof-for-php7
