### PR TITLE
Add buildkite pipline

### DIFF
--- a/.buildkite/build_extension.sh
+++ b/.buildkite/build_extension.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+PHP_VERSION=$1
+
+make distclean || true
+/opt/php/php-${PHP_VERSION}/bin/phpize
+CFLAGS="-O2" ./configure --with-php-config=/opt/php/php-${PHP_VERSION}/bin/php-config
+make -j2
+
+REPORT_EXIT_STATUS=1 /opt/php/php-${PHP_VERSION}/bin/php run-tests.php -p /opt/php/php-${PHP_VERSION}/bin/php --show-diff -d extension=`pwd`/.libs/tideways_xhprof.so -q

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,94 @@
+env:
+    NO_INTERACTION: 1
+
+steps:
+    - label: ":php: 7.3 amd64"
+      command: ./.buildkite/build_extension.sh 7.3
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.2 amd64"
+      command: ./.buildkite/build_extension.sh 7.2
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.1 amd64"
+      command: ./.buildkite/build_extension.sh 7.1
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.0 amd64"
+      command: ./.buildkite/build_extension.sh 7.0
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.3-zts amd64"
+      command: ./.buildkite/build_extension.sh 7.3-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.2-zts amd64"
+      command: ./.buildkite/build_extension.sh 7.2-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.1-zts amd64"
+      command: ./.buildkite/build_extension.sh 7.1-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+
+    - label: ":php: 7.3 i386"
+      command: ./.buildkite/build_extension.sh 7.3
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.2 i386"
+      command: ./.buildkite/build_extension.sh 7.2
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.1 i386"
+      command: ./.buildkite/build_extension.sh 7.1
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.0 i386"
+      command: ./.buildkite/build_extension.sh 7.0
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.3-zts i386"
+      command: ./.buildkite/build_extension.sh 7.3-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.2-zts i386"
+      command: ./.buildkite/build_extension.sh 7.2-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"
+
+    - label: ":php: 7.1-zts i386"
+      command: ./.buildkite/build_extension.sh 7.1-zts
+      agents:
+          phpbuild: "no-debug"
+          queue: "build"
+          arch: "i386"


### PR DESCRIPTION
Add integration into our buildkite infrastructure for amd64/i386 matrix on 7.0 - 7.3 + ZTS