### PR TITLE
Prevent nesting of XHProf Profiler.

### DIFF
--- a/tests/xhprof_009.phpt
+++ b/tests/xhprof_009.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Tideways: Nested Profiling Test
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function bar() {
+  return 1;
+}
+
+function foo($x) {
+  $sum = 0;
+  for ($idx = 0; $idx < 2; $idx++) {
+     $sum += bar();
+  }
+  return strlen("hello: {$x}");
+}
+
+// 1: Sanity test a simple profile run
+tideways_xhprof_enable();
+foo("this is a test");
+tideways_xhprof_enable();
+foo("this is a test");
+$output = tideways_xhprof_disable();
+
+print_canonical($output);
+echo "\n";
+--EXPECT--
+foo==>bar                               : ct=       4; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>foo                            : ct=       2; wt=*;
+main()==>tideways_xhprof_disable        : ct=       1; wt=*;
+main()==>tideways_xhprof_enable         : ct=       1; wt=*;

--- a/tests/xhprof_010.phpt
+++ b/tests/xhprof_010.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Tideways: Disabling without start first
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+
+var_dump(tideways_xhprof_disable());
+var_dump(tideways_xhprof_disable());
+echo "done\n";
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+done

--- a/tideways_xhprof.c
+++ b/tideways_xhprof.c
@@ -85,6 +85,10 @@ PHP_FUNCTION(tideways_xhprof_enable)
         return;
     }
 
+    if (TXRG(enabled) == 1) {
+        return;
+    }
+
     tracing_begin(flags TSRMLS_CC);
     tracing_enter_root_frame(TSRMLS_C);
 }


### PR DESCRIPTION
Fixes #103 by preventing the nesting, and overwriting of profiling data by calling `tideways_xhprof_enable` multiple times.

One problem could be that this leads to the first call to `tideways_xhprof_disable` to stop the profiling, maybe this should count the nesting?